### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Pr0methean/ScrapeFactordbPrpsRust/security/code-scanning/2](https://github.com/Pr0methean/ScrapeFactordbPrpsRust/security/code-scanning/2)

The best way to fix this problem is to add a `permissions` block with minimal required scopes to either the workflow root (global for all jobs) or at the job (`build`) level. Since there is only one job and no job-level sensitive operations are required, the fix is to add the following block under the workflow name, before `on:`:

```yaml
permissions:
  contents: read
```

This restricts the GITHUB_TOKEN permissions to read-only access to repository contents, which is the minimum required for operations such as checkout and caching. No other permissions (such as `pull-requests: write`) are required for this particular workflow. No special imports, method definitions, or package dependencies are necessary.

Edit `.github/workflows/rust.yml` by inserting the permissions block after the workflow name (`name: Rust`) and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
