### PR TITLE
Remove RUSTFLAGS from Rust CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,6 @@ env:
   U_DIGITS: ${{ inputs.u_digits }}
   PRP_START: ${{ inputs.prp_start }}
   SCCACHE_CACHE_SIZE: "10G"
-  RUSTFLAGS: "-C target-cpu=native"
   RUSTC_WRAPPER: "/usr/bin/sccache"
 jobs:
   build:


### PR DESCRIPTION
Removed RUSTFLAGS setting so that .cargo/config.toml will be used instead.